### PR TITLE
fix: update ACM certificate module dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -698,7 +698,7 @@ and provider aliases are unchanged before applying.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_certificates"></a> [certificates](#module\_certificates) | git::https://github.com/cloudopsworks/terraform-module-aws-acm-certificate.git | v1.2.9 |
+| <a name="module_certificates"></a> [certificates](#module\_certificates) | git::https://github.com/cloudopsworks/terraform-module-aws-acm-certificate.git | v1.3.6 |
 | <a name="module_tags"></a> [tags](#module\_tags) | cloudopsworks/tags/local | 1.0.9 |
 
 ## Resources

--- a/certificate.tf
+++ b/certificate.tf
@@ -8,7 +8,7 @@
 #
 
 module "certificates" {
-  source = "git::https://github.com/cloudopsworks/terraform-module-aws-acm-certificate.git?ref=v1.2.9"
+  source = "git::https://github.com/cloudopsworks/terraform-module-aws-acm-certificate.git?ref=v1.3.6"
   providers = {
     aws               = aws
     aws.cross_account = aws.cross_account

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -15,7 +15,7 @@
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_certificates"></a> [certificates](#module\_certificates) | git::https://github.com/cloudopsworks/terraform-module-aws-acm-certificate.git | v1.2.9 |
+| <a name="module_certificates"></a> [certificates](#module\_certificates) | git::https://github.com/cloudopsworks/terraform-module-aws-acm-certificate.git | v1.3.6 |
 | <a name="module_tags"></a> [tags](#module\_tags) | cloudopsworks/tags/local | 1.0.9 |
 
 ## Resources


### PR DESCRIPTION
## Summary

- Advance terraform-module-aws-acm-certificate from v1.2.9 to v1.3.6.
- Keep the Cognito module pinned to the latest published ACM helper release.
- Preserve the cross-account Terragrunt generate disable guard during review.

+semver: patch